### PR TITLE
Informing that I found a buildable app source close to android-ocr

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/mercuriete/android-mrz-reader
 
 The code shows clearly that https://github.com/mercuriete/android-mrz-reader it as fork of https://github.com/rmtheis/android-ocr 
 
-I will start to undo the new restriction to only scan passports MRZ numbers on https://github.com/jidhub/android-ocr-live-scanner
+I will start to undo the new restriction to only scan passports MRZ numbers in https://github.com/jidhub/android-ocr-live-scanner
 
 To pass the above message, I am using https://github.com/Bharat0908/android-ocr to post this message, because it is currently (as of 1/1/2025) the only active fork of https://github.com/rmtheis/android-ocr
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 #android-ocr
 * * *
 
+A newer version of https://github.com/rmtheis/android-ocr can be found at
+https://github.com/mercuriete/android-mrz-reader
+
+The code shows clearly that https://github.com/mercuriete/android-mrz-reader it as fork of https://github.com/rmtheis/android-ocr 
+
+I will start to undo the new restriction to only scan passports MRZ numbers on https://github.com/jidhub/android-ocr-live-scanner
+
+To pass the above message, I am using https://github.com/Bharat0908/android-ocr to post this message, because it is currently (as of 1/1/2025) the only active fork of https://github.com/rmtheis/android-ocr
+
+## Old version is
+
 An experimental app for Android that performs optical character recognition (OCR) on images captured using the device camera.
 
 Runs the Tesseract 3.03 OCR engine using a fork of Tesseract Tools for Android.


### PR DESCRIPTION
After having tried for two days to compile https://github.com/rmtheis/android-ocr I wanted to create this pull request to state that a newer version of https://github.com/rmtheis/android-ocr can be found at
https://github.com/mercuriete/android-mrz-reader

The code of https://github.com/mercuriete/android-mrz-reader clearly shows that it is a fork of https://github.com/rmtheis/android-ocr 

I will start to undo the new restriction to only scan passports MRZ numbers on https://github.com/jidhub/android-ocr-live-scanner

I am only using https://github.com/Bharat0908/android-ocr to post this message, because it is currently (as of 1/1/2025) the only active fork of https://github.com/rmtheis/android-ocr